### PR TITLE
Added support for batch uploads to fix #19

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,5 @@ $RECYCLE.BIN/
 C#/SyncClient.Windows81/SyncClient.Windows8.csproj
 C#/WinRTClient/packages.config
 /packages/SQLitePCL.3.8.5.1
+/Nuget/SyncClient.SQLite/lib
+/Tools

--- a/C#/SyncClient.Android/SyncClient.Android.csproj
+++ b/C#/SyncClient.Android/SyncClient.Android.csproj
@@ -15,7 +15,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v7.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/C#/SyncClient.Shared/SQLite/SQLiteConstants.cs
+++ b/C#/SyncClient.Shared/SQLite/SQLiteConstants.cs
@@ -79,6 +79,15 @@ namespace Microsoft.Synchronization.ClientServices.SQLite
 
         /// <summary>
         /// {0} : TableName
+        /// </summary>
+        public static String SelectChangeCount = 
+            "SELECT COUNT(*) from [{0}_tracking] t" + Environment.NewLine +
+            "Where (t.Oem_IsTombStone = 1  " + Environment.NewLine +
+            "OR t.Oem_IsDirty = 1 )  " + Environment.NewLine +
+            "And t.Oem_LastModifiedDate > ?";
+
+        /// <summary>
+        /// {0} : TableName
         /// {1} : Columns list
         /// {2} : Values
         /// </summary>

--- a/C#/SyncClient.Shared/SQLite/SQLiteContext.cs
+++ b/C#/SyncClient.Shared/SQLite/SQLiteContext.cs
@@ -310,7 +310,8 @@ namespace Microsoft.Synchronization.ClientServices.SQLite
                  var lastSyncDate = Configuration.LastSyncDate;
 
                  // get the number of changes
-                 var localChangeCount = Manager.GetChangeCount(state, lastSyncDate);
+                 bool uploadBatchingEnabled = this.uploadBatchSize > 0;
+                 var localChangeCount = uploadBatchingEnabled ? Manager.GetChangeCount(state, lastSyncDate) : 0;
 
                  // Get the changes from the storage layer (not the in-memory data that can change)
                  var changes = Manager.GetChanges(state, lastSyncDate, this.uploadBatchSize).ToList();

--- a/C#/SyncClient.Shared/SQLite/SQLiteContext.cs
+++ b/C#/SyncClient.Shared/SQLite/SQLiteContext.cs
@@ -67,6 +67,7 @@ namespace Microsoft.Synchronization.ClientServices.SQLite
         /// </summary>
         private bool isDisposed;
         private System.Net.CookieContainer cookieContainer;
+        private readonly int uploadBatchSize;
 
         /// <summary>
         /// Used to detect if this is the first sync to the server.
@@ -155,12 +156,14 @@ namespace Microsoft.Synchronization.ClientServices.SQLite
         /// <param name="scopeName">The scope name used to identify the scope on the service.</param>
         /// <param name="databasePath">Name of the database used to store entities.</param>
         /// <param name="uri">Uri of the scope.  Used to intialize the CacheController.</param>
+        /// <param name="cookieContainer"></param>
+        /// <param name="uploadBatchSize">If set, determines that the upload should be batched and the maximum number of rows to send in one batch (row count - not KB!)</param>
         /// <remarks>
         /// If the Uri specified is different from the one that is stored in the cache path, the
         /// Load method will throw an InvalidOperationException.
         /// 1/11/2015 Added an optional parameter to allow setting cookies
         /// </remarks>
-        public SQLiteContext(OfflineSchema schema, string scopeName, string databasePath, Uri uri, CookieContainer cookieContainer = null)
+        public SQLiteContext(OfflineSchema schema, string scopeName, string databasePath, Uri uri, CookieContainer cookieContainer = null, int uploadBatchSize = -1)
         {
             if (schema == null)
                 throw new ArgumentNullException("schema");
@@ -180,6 +183,7 @@ namespace Microsoft.Synchronization.ClientServices.SQLite
             this.scopeName = scopeName;
             // set cookiecontainer
             this.cookieContainer = cookieContainer;
+            this.uploadBatchSize = uploadBatchSize;
             this.databaseName = databasePath;
 
             bool isPath = databasePath.Contains('/') || databasePath.Contains('\\');
@@ -305,12 +309,15 @@ namespace Microsoft.Synchronization.ClientServices.SQLite
                  // Get the last date where Sync Occured
                  var lastSyncDate = Configuration.LastSyncDate;
 
+                 // get the number of changes
+                 var localChangeCount = Manager.GetChangeCount(state, lastSyncDate);
+
                  // Get the changes from the storage layer (not the in-memory data that can change)
-                 IEnumerable<IOfflineEntity> changes = Manager.GetChanges(state, lastSyncDate);
+                 var changes = Manager.GetChanges(state, lastSyncDate, this.uploadBatchSize).ToList();
 
                  // Fill the change list.
-                 changeSet.Data = changes.ToList();
-                 changeSet.IsLastBatch = true;
+                 changeSet.Data = changes;
+                 changeSet.IsLastBatch = (localChangeCount - changes.Count <= 0);
                  changeSet.ServerBlob = this.Configuration.AnchorBlob;
 
                  return changeSet;

--- a/C#/SyncClient.Shared/SQLite/SQLiteManager.cs
+++ b/C#/SyncClient.Shared/SQLite/SQLiteManager.cs
@@ -49,8 +49,6 @@ namespace Microsoft.Synchronization.ClientServices.SQLite
             this.sqliteHelper = new SQLiteHelper(this.localFilePath, this);
         }
 
-
-
         public TableMapping GetMapping<T>()
         {
             return GetMapping(typeof(T));
@@ -70,7 +68,6 @@ namespace Microsoft.Synchronization.ClientServices.SQLite
             }
             return map;
         }
-
    
         internal bool ScopeTableExist()
         {
@@ -98,8 +95,6 @@ namespace Microsoft.Synchronization.ClientServices.SQLite
 
         }
 
-        
-
         /// <summary>
         /// Create Table
         /// </summary>
@@ -107,7 +102,6 @@ namespace Microsoft.Synchronization.ClientServices.SQLite
         {
             this.sqliteHelper.CreateTable(table);
         }
-
 
         /// <summary>
         /// Create the scope info table
@@ -288,14 +282,26 @@ namespace Microsoft.Synchronization.ClientServices.SQLite
         }
 
         /// <summary>
+        /// Returns the number of changes that exist currently
+        /// </summary>
+        /// <param name="state"></param>
+        /// <param name="lastSyncDate"></param>
+        /// <returns></returns>
+        internal long GetChangeCount(Guid state, DateTime lastSyncDate)
+        {
+            return this.sqliteHelper.GetChangeCount(this.schema, lastSyncDate);
+        }
+
+        /// <summary>
         /// Get Change
         /// </summary>
         /// <param name="state">A Guid made to identify the sync process uniquely</param>
         /// <param name="lastSyncDate">Last Sync Date </param>
+        /// <param name="uploadBatchSize"></param>
         /// <returns></returns>
-        internal IEnumerable<IOfflineEntity> GetChanges(Guid state, DateTime lastSyncDate)
+        internal IEnumerable<IOfflineEntity> GetChanges(Guid state, DateTime lastSyncDate, int uploadBatchSize)
         {
-            IEnumerable<SQLiteOfflineEntity> getChanges = this.sqliteHelper.GetChanges(this.schema, lastSyncDate);
+            IEnumerable<SQLiteOfflineEntity> getChanges = this.sqliteHelper.GetChanges(this.schema, lastSyncDate, uploadBatchSize);
 
             // Save all the Reference. 
             // If there is a problem, rollback all informations on thoses Entities
@@ -364,8 +370,6 @@ namespace Microsoft.Synchronization.ClientServices.SQLite
             foreach (var groupedEntities in @group)
                 this.sqliteHelper.MergeEntities(groupedEntities.Type, groupedEntities.Entities.ToList());
         }
-
-
     }
 
     public class TableMapping
@@ -700,5 +704,4 @@ namespace Microsoft.Synchronization.ClientServices.SQLite
             return DefaultMaxStringLength;
         }
     }
-
 }

--- a/C#/SyncClient.iOS/SyncClient.iOS.csproj
+++ b/C#/SyncClient.iOS/SyncClient.iOS.csproj
@@ -6,7 +6,7 @@
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{9CEA0DB7-A4A3-4A9D-8B11-F7446A295F86}</ProjectGuid>
-    <ProjectTypeGuids>{6BC8ED88-2882-458C-8E55-DFD12B67127B};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.Synchronization.ClientServices</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
@@ -49,14 +49,14 @@
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
-    <Reference Include="monotouch" />
+    <Reference Include="Xamarin.iOS" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="..\SyncClient.Shared\SyncClient.Shared.projitems" Label="Shared" Condition="Exists('..\SyncClient.Shared\SyncClient.Shared.projitems')" />
-  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <Target Name="AfterBuild">
     <!--<Message Text="TargetFileName : $(TargetFileName) " Importance="high" />
     <Message Text="ProjectPriFileName : $(ProjectPriFileName) " Importance="high" />


### PR DESCRIPTION
Implemented optional **simple** batching support for uploads like proposed in this post:
http://stackoverflow.com/questions/4905193/how-to-use-batching-with-custom-change-tracking-in-sync-framework-2-1

* allows to configure batch size (row count)
* count total number of changes to see if current changeset is the last one
* select changes where lastmodified > ? and limit by batch size

this fixes #19 (Request Entity too large (413)) as at some point the config settings of

    <system.serviceModel>
      <bindings>
        <!-- allow Sync Framework to upload a lot of tasks (not only 65 kb)-->
        <webHttpBinding>
          <binding maxBufferPoolSize="2147483647" maxReceivedMessageSize="2147483647" maxBufferSize="2147483647" transferMode="Streamed">
          </binding>
        </webHttpBinding>
      </bindings>
    </system.serviceModel>

are not sufficient anymore. 